### PR TITLE
Fix switching to named sessions including a space

### DIFF
--- a/lua/telescope/_extensions/tmux/sessions.lua
+++ b/lua/telescope/_extensions/tmux/sessions.lua
@@ -73,7 +73,7 @@ local sessions = function(opts)
         attach_mappings = function(prompt_bufnr, map)
             actions.select_default:replace(function()
                 local selection = action_state.get_selected_entry()
-                vim.cmd(string.format('silent !tmux switchc -t %s -c %s', selection.value, current_client))
+                vim.cmd(string.format('silent !tmux switchc -t "%s" -c "%s"', selection.value, current_client))
                 actions.close(prompt_bufnr)
             end)
 

--- a/lua/telescope/_extensions/tmux/windows.lua
+++ b/lua/telescope/_extensions/tmux/windows.lua
@@ -82,7 +82,7 @@ local windows = function(opts)
       actions.select_default:replace(function()
         local selection = action_state.get_selected_entry()
         local selected_window_id = selection.value
-        vim.cmd(string.format('silent !tmux switchc -t %s -c %s', selected_window_id, current_client))
+        vim.cmd(string.format('silent !tmux switchc -t "%s" -c "%s"', selected_window_id, current_client))
         actions.close(prompt_bufnr)
       end)
       actions.close:enhance({


### PR DESCRIPTION
If a session included a space it wasn't possible to switch to it.

Wrapping all of the template strings in quotes when executing using `vim.cmd` fixes it. Perhaps not all template strings need wrapping, but it seemed sensible to do it anyway.

### How to test

- On master, using a named tmux session or window (I use `tmuxinator` to manage these) try to switch to a named tmux session
- See that switching fails
- See that it works using this branch