### PR TITLE
Add picker for file paths that show up in panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,24 @@ Find something in a pane's history scrollback
 :Telescope tmux pane_contents
 ```
 
+### Pane File Paths
+Find file paths in pane's history scrollback and open them for editing
+```
+:Telescope tmux pane_file_paths
+```
+
 ## Use with tmux display-popup
 Tmux 3.2's new `display-popup` command is a neat way to access the telescope picker when you are outside of Neovim.
 
 Add the following commands to your `.tmux.conf` which override the default tmux session and window pickers to use telescope.
+
+note: if you use a dashboard you may need to add `tmp.txt` or a filename at the end of the `nvim` commands.
 ```
 # use telescope-tmux for picking sessions and windows 
 bind s display-popup -E -w 80% -h 80% nvim -c ":Telescope tmux sessions quit_on_select=true"
 bind w display-popup -E -w 80% -h 80% nvim -c ":Telescope tmux windows quit_on_select=true"
+# for contents searching
+bind f display-popup -E -w 80% -h 80% nvim -c ":Telescope tmux pane_contents"
+# and for quick file edits
+bind f display-popup -E -w 80% -h 80% nvim -c ":Telescope tmux pane_file_paths"
 ```

--- a/lua/telescope/_extensions/tmux.lua
+++ b/lua/telescope/_extensions/tmux.lua
@@ -1,80 +1,10 @@
-local telescope = require('telescope')
-local utils = require('telescope.utils')
-local finders = require('telescope.finders')
-local pickers = require('telescope.pickers')
-local sorters = require('telescope.sorters')
-local actions = require('telescope.actions')
-local action_state = require('telescope.actions.state')
-local previewers = require('telescope.previewers')
+local pane_contents = require("telescope._extensions.tmux.pane_contents")
 
-local pane_contents = require'telescope._extensions.tmux.pane_contents'
-
-local pane_contents_cmd = function(opts)
-    local panes = pane_contents.list_panes()
-    local current_pane = pane_contents.get_current_pane_id()
-    local num_history_lines = opts.max_history_lines or 10000
-    local results = {}
-    for _, pane in ipairs(panes) do
-        local pane_id = pane.id
-        local session = pane.session
-        local contents = utils.get_os_command_output({'tmux', 'capture-pane', '-p', '-t', pane_id, '-S', -num_history_lines})
-        for i, line in ipairs(contents) do
-            table.insert(results, {pane=pane_id, session=session, line=line, line_num=i})
-        end
-    end
-
-    pickers.new(opts, {
-        prompt_title = 'Tmux Pane Contents',
-        finder = finders.new_table {
-            results = results,
-            entry_maker = function(result)
-                return {
-                    value = {
-                        pane = result.pane,
-                        line_num = result.line_num,
-                    },
-                    -- TODO: make the display prefix prettier
-                    display = result.session .. ":" .. result.pane .. " " .. result.line,
-                    ordinal = result.line,
-                    valid = result.pane ~= current_pane
-                }
-            end
-        },
-        sorter = sorters.get_generic_fuzzy_sorter(),
-        -- would prefer to use this when https://github.com/neovim/neovim/issues/14557 is fixed.
-        previewer = previewers.new_buffer_previewer({
-            define_preview = function(self, entry, status)
-                pane_contents.define_preview(entry, self.state.winid, self.state.bufnr, num_history_lines)
-            end,
-            get_buffer_by_name = function (self, entry)
-                return entry.value.pane
-            end
-        }),
-        attach_mappings = function(prompt_bufnr)
-            actions.select_default:replace(function()
-                local selection = action_state.get_selected_entry()
-                local pane = selection.value.pane
-                local line_num = selection.value.line_num
-                actions.close(prompt_bufnr)
-                vim.api.nvim_command("silent !tmux copy-mode -t \\" .. pane)
-                vim.api.nvim_command(string.format('silent !tmux send-keys -t \\%s -X history-top', pane))
-                vim.api.nvim_command(string.format('silent !tmux send-keys -t \\%s -X -N %s cursor-down', pane, line_num-1))
-                vim.api.nvim_command(string.format('silent !tmux send-keys -t \\%s -X select-line', pane))
-                -- pane IDs start with % so have to escape it
-                vim.api.nvim_command('silent !tmux switchc -t \\' .. pane)
-            end)
-
-            return true
-        end
-    }):find()
-end
-
-
-return telescope.register_extension {
+return require("telescope").register_extension({
     exports = {
-        --sessions = sessions,
-        sessions = require'telescope._extensions.tmux.sessions',
-        windows = require'telescope._extensions.tmux.windows',
-        pane_contents = pane_contents_cmd,
-    }
-}
+        sessions = require("telescope._extensions.tmux.sessions"),
+        windows = require("telescope._extensions.tmux.windows"),
+        pane_contents = pane_contents.cmd,
+        pane_file_paths = pane_contents.file_paths_cmd,
+    },
+})

--- a/lua/telescope/_extensions/tmux/pane_contents.lua
+++ b/lua/telescope/_extensions/tmux/pane_contents.lua
@@ -25,12 +25,12 @@ pane_contents.define_preview = function(entry, winid, bufid, num_history_lines)
         local pane_content =
             utils.get_os_command_output({ "tmux", "capture-pane", "-p", "-t", pane, "-S", -num_history_lines, "-e" })
         --local pane_content = {"one pane", "two pane", "three pane"}
-        vim.api.nvim_win_set_option(winid, "number", false)
-        vim.api.nvim_win_set_option(winid, "relativenumber", false)
-        vim.api.nvim_win_set_option(winid, "wrap", false)
+        vim.api.nvim_win_set_var(winid, "number", false)
+        vim.api.nvim_win_set_var(winid, "relativenumber", false)
+        vim.api.nvim_win_set_var(winid, "wrap", false)
 
         -- TODO: check for nvim-terminal.lua and only include term escape codes if plugin is present
-        vim.api.nvim_buf_set_option(bufid, "filetype", "terminal")
+        vim.api.nvim_buf_set_var(bufid, "filetype", "terminal")
         vim.api.nvim_buf_set_lines(bufid, 0, -1, false, pane_content)
     end
 

--- a/lua/telescope/_extensions/tmux/pane_contents.lua
+++ b/lua/telescope/_extensions/tmux/pane_contents.lua
@@ -1,13 +1,19 @@
-local utils = require('telescope.utils')
+local utils = require("telescope.utils")
+local finders = require("telescope.finders")
+local pickers = require("telescope.pickers")
+local sorters = require("telescope.sorters")
+local actions = require("telescope.actions")
+local action_state = require("telescope.actions.state")
+local previewers = require("telescope.previewers")
 
 local pane_contents = {}
 
-local ns_id = vim.api.nvim_create_namespace('telescope-tmux.previewers')
+local ns_id = vim.api.nvim_create_namespace("telescope-tmux.previewers")
 
 local function is_buf_empty(bufid)
     local line_count = vim.api.nvim_buf_line_count(bufid)
     local first_line = vim.api.nvim_buf_get_lines(bufid, 0, 1, false)[1]
-    return line_count == 1 and first_line == ''
+    return line_count == 1 and first_line == ""
 end
 pane_contents.define_preview = function(entry, winid, bufid, num_history_lines)
     local pane = entry.value.pane
@@ -16,7 +22,8 @@ pane_contents.define_preview = function(entry, winid, bufid, num_history_lines)
 
     if is_buf_empty(bufid) then
         -- TODO: can we avoid this call and reuse the original capture-pane output?
-        local pane_content = utils.get_os_command_output({'tmux', 'capture-pane', '-p', '-t', pane, '-S', -num_history_lines, '-e'})
+        local pane_content =
+            utils.get_os_command_output({ "tmux", "capture-pane", "-p", "-t", pane, "-S", -num_history_lines, "-e" })
         --local pane_content = {"one pane", "two pane", "three pane"}
         vim.api.nvim_win_set_option(winid, "number", false)
         vim.api.nvim_win_set_option(winid, "relativenumber", false)
@@ -28,24 +35,199 @@ pane_contents.define_preview = function(entry, winid, bufid, num_history_lines)
     end
 
     vim.api.nvim_buf_clear_namespace(bufid, ns_id, 0, -1)
-    vim.api.nvim_buf_add_highlight(bufid, ns_id, "TelescopePreviewLine", line_num-1, 0, -1)
-    vim.api.nvim_win_set_cursor(winid, {line_num, 0})
+    vim.api.nvim_buf_add_highlight(bufid, ns_id, "TelescopePreviewLine", line_num - 1, 0, -1)
+    vim.api.nvim_win_set_cursor(winid, { line_num, 0 })
 end
 
 pane_contents.list_panes = function()
-    local raw_panes =  utils.get_os_command_output({'tmux', 'list-panes', '-a', '-F', '#{pane_id}\t#{session_name}\t'})
+    local raw_panes = utils.get_os_command_output({ "tmux", "list-panes", "-a", "-F", "#{pane_id}\t#{session_name}\t" })
     local panes = {}
     for _, pane in ipairs(raw_panes) do
         local it = string.gmatch(pane, "[^\t]*\t")
         local id = it():sub(1, -2)
         local session = it():sub(1, -2)
-        table.insert(panes, {id=id, session=session})
+        table.insert(panes, { id = id, session = session })
     end
     return panes
 end
 
 pane_contents.get_current_pane_id = function()
-    return utils.get_os_command_output({'tmux', 'display-message', '-p', '#{pane_id}'})[1]
+    return utils.get_os_command_output({ "tmux", "display-message", "-p", "#{pane_id}" })[1]
+end
+
+pane_contents.cmd = function(opts)
+    local panes = pane_contents.list_panes()
+    local current_pane = pane_contents.get_current_pane_id()
+    local num_history_lines = opts.max_history_lines or 10000
+    local results = {}
+    for _, pane in ipairs(panes) do
+        local pane_id = pane.id
+        local session = pane.session
+        local contents =
+            utils.get_os_command_output({ "tmux", "capture-pane", "-p", "-t", pane_id, "-S", -num_history_lines })
+        for i, line in ipairs(contents) do
+            table.insert(results, { pane = pane_id, session = session, line = line, line_num = i })
+        end
+    end
+
+    pickers
+        .new(opts, {
+            prompt_title = "Tmux Pane Contents",
+            finder = finders.new_table({
+                results = results,
+                entry_maker = function(result)
+                    return {
+                        value = {
+                            pane = result.pane,
+                            line_num = result.line_num,
+                        },
+                        -- TODO: make the display prefix prettier
+                        display = result.session .. ":" .. result.pane .. " " .. result.line,
+                        ordinal = result.line,
+                        valid = result.pane ~= current_pane,
+                    }
+                end,
+            }),
+            sorter = sorters.get_generic_fuzzy_sorter(),
+            -- would prefer to use this when https://github.com/neovim/neovim/issues/14557 is fixed.
+            previewer = previewers.new_buffer_previewer({
+                define_preview = function(self, entry, _)
+                    pane_contents.define_preview(entry, self.state.winid, self.state.bufnr, num_history_lines)
+                end,
+                get_buffer_by_name = function(_, entry)
+                    return entry.value.pane
+                end,
+            }),
+            attach_mappings = function(prompt_bufnr)
+                actions.select_default:replace(function()
+                    local selection = action_state.get_selected_entry()
+                    local pane = selection.value.pane
+                    local line_num = selection.value.line_num
+                    actions.close(prompt_bufnr)
+                    vim.api.nvim_command("silent !tmux copy-mode -t \\" .. pane)
+                    vim.api.nvim_command(string.format("silent !tmux send-keys -t \\%s -X history-top", pane))
+                    vim.api.nvim_command(
+                        string.format("silent !tmux send-keys -t \\%s -X -N %s cursor-down", pane, line_num - 1)
+                    )
+                    vim.api.nvim_command(string.format("silent !tmux send-keys -t \\%s -X select-line", pane))
+                    -- pane IDs start with % so have to escape it
+                    vim.api.nvim_command("silent !tmux switchc -t \\" .. pane)
+                end)
+
+                return true
+            end,
+        })
+        :find()
+end
+
+pane_contents.file_paths_cmd = function(opts)
+    local Path = require("plenary.path")
+    local panes = pane_contents.list_panes()
+    local current_pane = utils.get_os_command_output({ "echo", "${TMUX_PANE}" })
+    local num_history_lines = opts.max_history_lines or 10000
+    local grep_cmd = opts.grep_cmd or "grep -oP"
+    -- regex to find paths and optional "line:col" at the end
+    local regex = opts.regex or "(([.\\w\\-~\\$@]+)?(/?[\\w\\-@]+)+)\\.[a-zA-Z]\\w{0,5}(:\\d*:\\d*)?"
+    local results = {}
+    for _, pane in ipairs(panes) do
+        local pane_id = pane.id
+        if pane_id ~= current_pane then
+            local pane_path = utils.get_os_command_output({
+                "tmux",
+                "display",
+                "-pt",
+                pane_id,
+                "#{pane_current_path}",
+            })[1] or ""
+            local command_str = "tmux capture-pane -p -t "
+                .. pane_id
+                .. " -S "
+                .. -num_history_lines
+                .. " | "
+                .. grep_cmd
+                .. " '"
+                .. regex
+                .. "' | tr -d ' '"
+            local contents = utils.get_os_command_output({
+                "sh",
+                "-c",
+                command_str,
+            })
+            for _, line in ipairs(contents) do
+                -- parse path, line, col
+                local splits = {}
+                local i = 1
+                for part in string.gmatch(line, "[^:]+") do
+                    splits[i] = part
+                    i = i + 1
+                end
+                local path = Path:new(splits[1])
+                if not path:is_absolute() then
+                    path = Path:new(pane_path, path)
+                end
+                if path:is_file() then
+                    local result = { path = path:normalize(), lnum = splits[2], cnum = splits[3] }
+                    local key = result.path .. ":" .. (result.lnum or "") .. ":" .. (result.cnum or "")
+                    if results[key] == nil then
+                        results[key] = result
+                    end
+                end
+            end
+        end
+    end
+
+    local make_results = function()
+        local values = {}
+        for _, v in pairs(results) do
+            table.insert(values, {
+                path = v.path,
+                lnum = tonumber(v.lnum),
+                cnum = tonumber(v.cnum),
+            })
+        end
+        return values
+    end
+    pickers
+        .new(opts, {
+            prompt_title = "Tmux Pane File Paths",
+            finder = finders.new_table({
+                results = make_results(),
+                entry_maker = function(result)
+                    local path = result.path
+                    local line_num = result.lnum
+                    local col_num = result.cnum
+                    local line_col = ""
+                    if line_num then
+                        line_col = ":" .. line_num .. ":" .. col_num
+                    end
+                    return {
+                        value = result,
+                        filename = path,
+                        lnum = line_num,
+                        display = path .. line_col,
+                        ordinal = path,
+                    }
+                end,
+            }),
+            sorter = sorters.get_generic_fuzzy_sorter(),
+            previewer = require("telescope.config").values.grep_previewer(opts),
+            attach_mappings = function(prompt_bufnr)
+                actions.select_default:replace(function()
+                    local selection = action_state.get_selected_entry()
+                    actions.close(prompt_bufnr)
+                    local path = selection.value.path
+                    local line_num = selection.value.lnum
+                    local col_num = selection.value.cnum
+                    -- open up file
+                    vim.cmd("e " .. path)
+                    if line_num and col_num then
+                        vim.api.nvim_call_function("cursor", { line_num, col_num })
+                    end
+                end)
+                return true
+            end,
+        })
+        :find()
 end
 
 return pane_contents

--- a/lua/telescope/_extensions/tmux/pane_contents.lua
+++ b/lua/telescope/_extensions/tmux/pane_contents.lua
@@ -127,7 +127,7 @@ pane_contents.file_paths_cmd = function(opts)
     local num_history_lines = opts.max_history_lines or 10000
     local grep_cmd = opts.grep_cmd or "grep -oP"
     -- regex to find paths and optional "line:col" at the end
-    local regex = opts.regex or "(([.\\w\\-~\\$@]+)?(/?[\\w\\-@]+)+)\\.[a-zA-Z]\\w{0,5}(:\\d*:\\d*)?"
+    local regex = opts.regex or "(([.\\w\\-~\\$@]+)(\\/?[\\w\\-@]+)+\\/?)\\.([\\w]+)(:\\d*:\\d*)?"
     local results = {}
     for _, pane in ipairs(panes) do
         local pane_id = pane.id

--- a/lua/telescope/_extensions/tmux/sessions.lua
+++ b/lua/telescope/_extensions/tmux/sessions.lua
@@ -1,34 +1,46 @@
-local tutils = require('telescope.utils')
-local finders = require('telescope.finders')
-local pickers = require('telescope.pickers')
-local sorters = require('telescope.sorters')
-local actions = require('telescope.actions')
-local action_state = require('telescope.actions.state')
-local previewers = require('telescope.previewers')
-local transform_mod = require('telescope.actions.mt').transform_mod
-local utils = require'telescope._extensions.tmux.utils'
-local tmux_commands = require 'telescope._extensions.tmux.tmux_commands'
+local tutils = require("telescope.utils")
+local finders = require("telescope.finders")
+local pickers = require("telescope.pickers")
+local sorters = require("telescope.sorters")
+local actions = require("telescope.actions")
+local action_state = require("telescope.actions.state")
+local previewers = require("telescope.previewers")
+local transform_mod = require("telescope.actions.mt").transform_mod
+local utils = require("telescope._extensions.tmux.utils")
+local tmux_commands = require("telescope._extensions.tmux.tmux_commands")
 
 local sessions = function(opts)
     opts = utils.apply_default_layout(opts)
-    local session_ids = tmux_commands.list_sessions{format = tmux_commands.session_id_fmt}
-    local user_formatted_session_names = tmux_commands.list_sessions{format = opts.entry_format or tmux_commands.session_name_fmt}
+    local session_ids = tmux_commands.list_sessions({ format = tmux_commands.session_id_fmt })
+    local user_formatted_session_names =
+        tmux_commands.list_sessions({ format = opts.entry_format or tmux_commands.session_name_fmt })
     local formatted_to_real_session_map = {}
     for i, v in ipairs(user_formatted_session_names) do
         formatted_to_real_session_map[v] = session_ids[i]
     end
 
     -- FIXME: This command can display a session name even if you are in a seperate terminal session that isn't using tmux
-    local current_session = tutils.get_os_command_output({'tmux', 'display-message', '-p', tmux_commands.session_id_fmt})[1]
-    local current_client = tutils.get_os_command_output({'tmux', 'display-message', '-p', '#{client_tty}'})[1]
+    local current_session =
+        tutils.get_os_command_output({ "tmux", "display-message", "-p", tmux_commands.session_id_fmt })[1]
+    local current_client = tutils.get_os_command_output({ "tmux", "display-message", "-p", "#{client_tty}" })[1]
 
     local custom_actions = transform_mod({
         create_new_session = function(prompt_bufnr)
             local new_session = action_state.get_current_line()
             local confirmation = vim.fn.input("Create session '" .. new_session .. "'? [Y/n] ")
-            if string.lower(confirmation) ~= 'y' then return end
-            local new_session_id = tutils.get_os_command_output{"tmux", "new-session", "-dP", "-s", new_session, "-F", "#{session_id}"}[1]
-            tutils.get_os_command_output{"tmux", "switch-client", "-t", new_session_id, "-c", current_client}
+            if string.lower(confirmation) ~= "y" then
+                return
+            end
+            local new_session_id = tutils.get_os_command_output({
+                "tmux",
+                "new-session",
+                "-dP",
+                "-s",
+                new_session,
+                "-F",
+                "#{session_id}",
+            })[1]
+            tutils.get_os_command_output({ "tmux", "switch-client", "-t", new_session_id, "-c", current_client })
             actions.close(prompt_bufnr)
         end,
         delete_session = function(prompt_bufnr)
@@ -36,65 +48,70 @@ local sessions = function(opts)
             local session_id = entry.value
             local session_display = entry.display
             local confirmation = vim.fn.input("Kill session '" .. session_display .. "'? [Y/n] ")
-            if string.lower(confirmation) ~= 'y' then return end
-            tutils.get_os_command_output{"tmux", "kill-session", "-t", session_id}
+            if string.lower(confirmation) ~= "y" then
+                return
+            end
+            tutils.get_os_command_output({ "tmux", "kill-session", "-t", session_id })
             actions.close(prompt_bufnr)
         end,
         rename_session = function(prompt_bufnr)
             local session = action_state.get_selected_entry().value
             local new_session_name = vim.fn.input("Enter new session name: ")
-            if string.lower(new_session_name) == '' then return end
-            tutils.get_os_command_output{"tmux", "rename-session", "-t", session, new_session_name}
+            if string.lower(new_session_name) == "" then
+                return
+            end
+            tutils.get_os_command_output({ "tmux", "rename-session", "-t", session, new_session_name })
             actions.close(prompt_bufnr)
         end,
     })
 
+    pickers
+        .new(opts, {
+            prompt_title = "Tmux Sessions",
+            finder = finders.new_table({
+                results = user_formatted_session_names,
+                entry_maker = function(result)
+                    return {
+                        value = result,
+                        display = result,
+                        ordinal = result,
+                        valid = formatted_to_real_session_map[result] ~= current_session,
+                    }
+                end,
+            }),
+            sorter = sorters.get_generic_fuzzy_sorter(),
+            previewer = previewers.new_termopen_previewer({
+                get_command = function(entry, status)
+                    local session_name = formatted_to_real_session_map[entry.value]
+                    return { "tmux", "attach-session", "-t", session_name, "-r" }
+                end,
+            }),
+            attach_mappings = function(prompt_bufnr, map)
+                actions.select_default:replace(function()
+                    local selection = action_state.get_selected_entry()
+                    vim.cmd(string.format('silent !tmux switchc -t "%s" -c "%s"', selection.value, current_client))
+                    actions.close(prompt_bufnr)
+                end)
 
-    pickers.new(opts, {
-        prompt_title = 'Tmux Sessions',
-        finder = finders.new_table {
-            results = user_formatted_session_names,
-            entry_maker = function(result)
-                return {
-                    value = result,
-                    display = result,
-                    ordinal = result,
-                    valid = formatted_to_real_session_map[result] ~=  current_session
-                }
-            end
-        },
-        sorter = sorters.get_generic_fuzzy_sorter(),
-        previewer = previewers.new_termopen_previewer({
-            get_command = function(entry, status)
-                local session_name = formatted_to_real_session_map[entry.value]
-                return {'tmux', 'attach-session', '-t', session_name, '-r'}
-            end
-        }),
-        attach_mappings = function(prompt_bufnr, map)
-            actions.select_default:replace(function()
-                local selection = action_state.get_selected_entry()
-                vim.cmd(string.format('silent !tmux switchc -t "%s" -c "%s"', selection.value, current_client))
-                actions.close(prompt_bufnr)
-            end)
+                actions.close:enhance({
+                    post = function()
+                        if opts.quit_on_select then
+                            vim.cmd("q!")
+                        end
+                    end,
+                })
 
-            actions.close:enhance({
-                post = function ()
-                    if opts.quit_on_select then
-                        vim.cmd('q!')
-                    end
-                end
-            })
+                map("i", "<c-a>", custom_actions.create_new_session)
+                map("n", "<c-a>", custom_actions.create_new_session)
+                map("i", "<c-d>", custom_actions.delete_session)
+                map("n", "<c-d>", custom_actions.delete_session)
+                map("i", "<c-r>", custom_actions.rename_session)
+                map("n", "<c-r>", custom_actions.rename_session)
 
-            map('i', '<c-a>', custom_actions.create_new_session)
-            map('n', '<c-a>', custom_actions.create_new_session)
-            map('i', '<c-d>', custom_actions.delete_session)
-            map('n', '<c-d>', custom_actions.delete_session)
-            map('i', '<c-r>', custom_actions.rename_session)
-            map('n', '<c-r>', custom_actions.rename_session)
-
-            return true
-        end,
-    }):find()
+                return true
+            end,
+        })
+        :find()
 end
 
 return sessions

--- a/lua/telescope/_extensions/tmux/tmux_commands.lua
+++ b/lua/telescope/_extensions/tmux/tmux_commands.lua
@@ -1,4 +1,4 @@
-local tutils = require('telescope.utils')
+local tutils = require("telescope.utils")
 
 local tmux_commands = {}
 
@@ -9,36 +9,35 @@ tmux_commands.session_id_fmt = "#{session_id}"
 tmux_commands.session_name_fmt = "#S"
 
 tmux_commands.list_windows = function(opts)
-  local cmd = {'tmux', 'list-windows', '-a'}
-  if opts.format ~= nil then
-    table.insert(cmd, "-F")
-    table.insert(cmd, opts.format)
-  end
-  return tutils.get_os_command_output(cmd)
+    local cmd = { "tmux", "list-windows", "-a" }
+    if opts.format ~= nil then
+        table.insert(cmd, "-F")
+        table.insert(cmd, opts.format)
+    end
+    return tutils.get_os_command_output(cmd)
 end
 
 tmux_commands.list_sessions = function(opts)
- local cmd = {'tmux', 'list-sessions'}
- if opts.format ~= nil then
-   table.insert(cmd, "-F")
-   table.insert(cmd, opts.format)
- end
- return tutils.get_os_command_output(cmd)
+    local cmd = { "tmux", "list-sessions" }
+    if opts.format ~= nil then
+        table.insert(cmd, "-F")
+        table.insert(cmd, opts.format)
+    end
+    return tutils.get_os_command_output(cmd)
 end
 
 tmux_commands.get_base_index_option = function()
-  return tutils.get_os_command_output{'tmux', 'show-options', '-gv', 'base-index'}[1]
+    return tutils.get_os_command_output({ "tmux", "show-options", "-gv", "base-index" })[1]
 end
 
 tmux_commands.link_window = function(src_window, target_window)
-  local src = src_window  or error("src_window is required")
-  local target = target_window  or error("target_window is required")
-  return tutils.get_os_command_output{'tmux', 'link-window', "-kd", '-s', src, "-t", target}
+    local src = src_window or error("src_window is required")
+    local target = target_window or error("target_window is required")
+    return tutils.get_os_command_output({ "tmux", "link-window", "-kd", "-s", src, "-t", target })
 end
 
 tmux_commands.kill_window = function(target)
-  return tutils.get_os_command_output{"tmux", "kill-window", "-t", target}
+    return tutils.get_os_command_output({ "tmux", "kill-window", "-t", target })
 end
-
 
 return tmux_commands

--- a/lua/telescope/_extensions/tmux/utils.lua
+++ b/lua/telescope/_extensions/tmux/utils.lua
@@ -1,7 +1,7 @@
 local utils = {}
 
 utils.apply_default_layout = function(opts)
-    return vim.tbl_extend("keep", opts, {layout_strategy='horizontal', layout_config={preview_width=0.8}})
+    return vim.tbl_extend("keep", opts, { layout_strategy = "horizontal", layout_config = { preview_width = 0.8 } })
 end
 
 return utils

--- a/lua/telescope/_extensions/tmux/windows.lua
+++ b/lua/telescope/_extensions/tmux/windows.lua
@@ -1,103 +1,111 @@
-local tutils = require('telescope.utils')
-local finders = require('telescope.finders')
-local pickers = require('telescope.pickers')
-local sorters = require('telescope.sorters')
-local actions = require('telescope.actions')
-local transform_mod = require('telescope.actions.mt').transform_mod
-local action_state = require('telescope.actions.state')
-local previewers = require('telescope.previewers')
-local utils = require'telescope._extensions.tmux.utils'
-local tmux_commands = require'telescope._extensions.tmux.tmux_commands'
+local tutils = require("telescope.utils")
+local finders = require("telescope.finders")
+local pickers = require("telescope.pickers")
+local sorters = require("telescope.sorters")
+local actions = require("telescope.actions")
+local transform_mod = require("telescope.actions.mt").transform_mod
+local action_state = require("telescope.actions.state")
+local previewers = require("telescope.previewers")
+local utils = require("telescope._extensions.tmux.utils")
+local tmux_commands = require("telescope._extensions.tmux.tmux_commands")
 
-local custom_actions = transform_mod{
-  delete_window = function(prompt_bufnr)
-      local entry = action_state.get_selected_entry()
-      local window_id = entry.value
-      local window_display = entry.display
-      local confirmation = vim.fn.input("Kill window '" .. window_display .. "'? [Y/n] ")
-      if string.lower(confirmation) ~= 'y' then return end
-      tmux_commands.kill_window(window_id)
-      actions.close(prompt_bufnr)
-  end,
-}
-
+local custom_actions = transform_mod({
+    delete_window = function(prompt_bufnr)
+        local entry = action_state.get_selected_entry()
+        local window_id = entry.value
+        local window_display = entry.display
+        local confirmation = vim.fn.input("Kill window '" .. window_display .. "'? [Y/n] ")
+        if string.lower(confirmation) ~= "y" then
+            return
+        end
+        tmux_commands.kill_window(window_id)
+        actions.close(prompt_bufnr)
+    end,
+})
 
 local windows = function(opts)
-  local list_windows = tmux_commands.list_windows
-  opts = utils.apply_default_layout(opts)
+    local list_windows = tmux_commands.list_windows
+    opts = utils.apply_default_layout(opts)
 
-  local window_ids = list_windows({format = tmux_commands.window_id_fmt})
-  local display_windows = list_windows({format = opts.entry_format or '#S: #W'})
-  -- FIXME: This command can display a session name even if you are in a seperate terminal session that isn't using tmux
-  local current_window = tutils.get_os_command_output({'tmux', 'display-message', '-p', tmux_commands.window_id_fmt})[1]
+    local window_ids = list_windows({ format = tmux_commands.window_id_fmt })
+    local display_windows = list_windows({ format = opts.entry_format or "#S: #W" })
+    -- FIXME: This command can display a session name even if you are in a seperate terminal session that isn't using tmux
+    local current_window =
+        tutils.get_os_command_output({ "tmux", "display-message", "-p", tmux_commands.window_id_fmt })[1]
 
-  local entries = {}
-  for i, v in ipairs(display_windows) do
-    local entry = {
-      value = window_ids[i],
-      display = v,
-      ordinal = v,
-      valid = window_ids[i] ~= current_window
-    }
-    table.insert(entries, entry)
-  end
-
-  local dummy_session_name = "telescope-tmux-previewer"
-  local current_client = tutils.get_os_command_output({'tmux', 'display-message', '-p', '#{client_tty}'})[1]
-
-  local base_index = tmux_commands.get_base_index_option()
-
-  pickers.new(opts, {
-    prompt_title = 'Tmux Windows',
-    finder = finders.new_table {
-        results = entries,
-        entry_maker = function(res) return res end
-    },
-    sorter = sorters.get_generic_fuzzy_sorter(),
-    previewer = previewers.new_buffer_previewer({
-      setup = function(self)
-        vim.api.nvim_command(string.format("silent !tmux new-session -s %s -d", dummy_session_name))
-        return {}
-      end,
-      define_preview = function(self, entry, status)
-        -- We have to set the window buf manually to avoid a race condition where we try to attach to
-        -- the tmux sessions before the buffer has been set in the window. This is because Telescope
-        -- calls nvim_win_set_buf inside vim.schedule()
-        vim.api.nvim_win_set_buf(self.state.winid, self.state.bufnr)
-        local window_id = entry.value
-        vim.api.nvim_buf_call(self.state.bufnr, function()
-            -- kil the job running in previous previewer
-            if tutils.job_is_running(self.state.termopen_id) then vim.fn.jobstop(self.state.termopen_id) end
-            local target_window_id = dummy_session_name .. ":" .. base_index
-            tmux_commands.link_window(window_id, target_window_id)
-            -- Need -r here to prevent resizing the window which will distort the view on the real client
-            self.state.termopen_id = vim.fn.termopen(string.format("tmux attach -t %s -r", dummy_session_name))
-        end)
-      end,
-      teardown = function(self)
-        vim.api.nvim_command(string.format("silent !tmux kill-session -t %s", dummy_session_name))
-      end
-    }),
-    attach_mappings = function(prompt_bufnr, map)
-      actions.select_default:replace(function()
-        local selection = action_state.get_selected_entry()
-        local selected_window_id = selection.value
-        vim.cmd(string.format('silent !tmux switchc -t "%s" -c "%s"', selected_window_id, current_client))
-        actions.close(prompt_bufnr)
-      end)
-      actions.close:enhance({
-        post = function ()
-          if opts.quit_on_select then
-            vim.cmd('q')
-          end
-        end
-      })
-      map('i', '<c-d>', custom_actions.delete_window)
-      map('n', '<c-d>', custom_actions.delete_window)
-      return true
+    local entries = {}
+    for i, v in ipairs(display_windows) do
+        local entry = {
+            value = window_ids[i],
+            display = v,
+            ordinal = v,
+            valid = window_ids[i] ~= current_window,
+        }
+        table.insert(entries, entry)
     end
-}):find()
+
+    local dummy_session_name = "telescope-tmux-previewer"
+    local current_client = tutils.get_os_command_output({ "tmux", "display-message", "-p", "#{client_tty}" })[1]
+
+    local base_index = tmux_commands.get_base_index_option()
+
+    pickers
+        .new(opts, {
+            prompt_title = "Tmux Windows",
+            finder = finders.new_table({
+                results = entries,
+                entry_maker = function(res)
+                    return res
+                end,
+            }),
+            sorter = sorters.get_generic_fuzzy_sorter(),
+            previewer = previewers.new_buffer_previewer({
+                setup = function(self)
+                    vim.api.nvim_command(string.format("silent !tmux new-session -s %s -d", dummy_session_name))
+                    return {}
+                end,
+                define_preview = function(self, entry, status)
+                    -- We have to set the window buf manually to avoid a race condition where we try to attach to
+                    -- the tmux sessions before the buffer has been set in the window. This is because Telescope
+                    -- calls nvim_win_set_buf inside vim.schedule()
+                    vim.api.nvim_win_set_buf(self.state.winid, self.state.bufnr)
+                    local window_id = entry.value
+                    vim.api.nvim_buf_call(self.state.bufnr, function()
+                        -- kil the job running in previous previewer
+                        if tutils.job_is_running(self.state.termopen_id) then
+                            vim.fn.jobstop(self.state.termopen_id)
+                        end
+                        local target_window_id = dummy_session_name .. ":" .. base_index
+                        tmux_commands.link_window(window_id, target_window_id)
+                        -- Need -r here to prevent resizing the window which will distort the view on the real client
+                        self.state.termopen_id =
+                            vim.fn.termopen(string.format("tmux attach -t %s -r", dummy_session_name))
+                    end)
+                end,
+                teardown = function(self)
+                    vim.api.nvim_command(string.format("silent !tmux kill-session -t %s", dummy_session_name))
+                end,
+            }),
+            attach_mappings = function(prompt_bufnr, map)
+                actions.select_default:replace(function()
+                    local selection = action_state.get_selected_entry()
+                    local selected_window_id = selection.value
+                    vim.cmd(string.format('silent !tmux switchc -t "%s" -c "%s"', selected_window_id, current_client))
+                    actions.close(prompt_bufnr)
+                end)
+                actions.close:enhance({
+                    post = function()
+                        if opts.quit_on_select then
+                            vim.cmd("q")
+                        end
+                    end,
+                })
+                map("i", "<c-d>", custom_actions.delete_window)
+                map("n", "<c-d>", custom_actions.delete_window)
+                return true
+            end,
+        })
+        :find()
 end
 
 return windows
-

--- a/lua/tests/tmux_spec.lua
+++ b/lua/tests/tmux_spec.lua
@@ -1,59 +1,60 @@
-package.path = 'lua/telescope/_extensions/?.lua;' .. package.path
+package.path = "lua/telescope/_extensions/?.lua;" .. package.path
 
-local mock = require('luassert.mock')
+local mock = require("luassert.mock")
 
 describe("pane_contents", function()
-  local pane_contents = require'telescope._extensions.tmux.pane_contents'
+    local pane_contents = require("telescope._extensions.tmux.pane_contents")
 
-  it("should display pane contents with correct line numbering", function()
-      local pane = "%1"
-      local line_num = 1
-      local line = "here is a line to display"
-      local entry = {
-        value = {
-            pane = pane,
-            line_num = line_num,
-        },
-        -- TODO: make the display prefix prettier
-        display = pane .. ":" .. line_num .. ": " .. line,
-        ordinal = line,
-        valid = true
-    }
-    local winid = vim.api.nvim_get_current_win()
-    local bufid = vim.api.nvim_create_buf(true, true)
-    local utils = mock(require('telescope.utils'), true)
-    utils.get_os_command_output.returns{line}
+    it("should display pane contents with correct line numbering", function()
+        local pane = "%1"
+        local line_num = 1
+        local line = "here is a line to display"
+        local entry = {
+            value = {
+                pane = pane,
+                line_num = line_num,
+            },
+            -- TODO: make the display prefix prettier
+            display = pane .. ":" .. line_num .. ": " .. line,
+            ordinal = line,
+            valid = true,
+        }
+        local winid = vim.api.nvim_get_current_win()
+        local bufid = vim.api.nvim_create_buf(true, true)
+        local utils = mock(require("telescope.utils"), true)
+        utils.get_os_command_output.returns({ line })
 
-    pane_contents.define_preview(entry, winid, bufid, 100)
-    vim.wait(100)
-    local actual_line = vim.api.nvim_buf_get_lines(bufid, line_num-1, line_num, true)[1]
-    assert.equals(line, actual_line)
-  end)
+        pane_contents.define_preview(entry, winid, bufid, 100)
+        vim.wait(100)
+        local actual_line = vim.api.nvim_buf_get_lines(bufid, line_num - 1, line_num, true)[1]
+        assert.equals(line, actual_line)
+    end)
 
-  it("should correctly display tmux capture-pane output with terminal escape codes", function()
-      local pane = "%1"
-      local line_num = 2
-      local line = "here is a line to display"
-      local entry = {
-        value = {
-            pane = pane,
-            line_num = line_num,
-        },
-        -- TODO: make the display prefix prettier
-        display = pane .. ":" .. line_num .. ": " .. line,
-        ordinal = line,
-        valid = true
-    }
-    local winid = vim.api.nvim_get_current_win()
-    local bufid = vim.api.nvim_create_buf(true, true)
-    local utils = mock(require('telescope.utils'), true)
-    local lines = vim.fn.readfile("lua/tests/fixtures/pane_contents_output.txt")
-    utils.get_os_command_output.returns(lines)
+    it("should correctly display tmux capture-pane output with terminal escape codes", function()
+        local pane = "%1"
+        local line_num = 2
+        local line = "here is a line to display"
+        local entry = {
+            value = {
+                pane = pane,
+                line_num = line_num,
+            },
+            -- TODO: make the display prefix prettier
+            display = pane .. ":" .. line_num .. ": " .. line,
+            ordinal = line,
+            valid = true,
+        }
+        local winid = vim.api.nvim_get_current_win()
+        local bufid = vim.api.nvim_create_buf(true, true)
+        local utils = mock(require("telescope.utils"), true)
+        local lines = vim.fn.readfile("lua/tests/fixtures/pane_contents_output.txt")
+        utils.get_os_command_output.returns(lines)
 
-    pane_contents.define_preview(entry, winid, bufid, 100)
-    vim.wait(100)
-    local actual_line = vim.api.nvim_buf_get_lines(bufid, line_num-1, line_num, true)[1]
-    local expected = "[38;2;80;73;69m~                              [38;2;102;92;84m│[38;2;124;111;100m    [38;2;235;219;178missues https://github.com/syncthing/syncthing/issues/6252. Also some remnance here https://github.com/gsantner/markor/issues/954#issuecomment-700337136                "
-    assert.equals(expected, actual_line)
-  end)
+        pane_contents.define_preview(entry, winid, bufid, 100)
+        vim.wait(100)
+        local actual_line = vim.api.nvim_buf_get_lines(bufid, line_num - 1, line_num, true)[1]
+        local expected =
+            "[38;2;80;73;69m~                              [38;2;102;92;84m│[38;2;124;111;100m    [38;2;235;219;178missues https://github.com/syncthing/syncthing/issues/6252. Also some remnance here https://github.com/gsantner/markor/issues/954#issuecomment-700337136                "
+        assert.equals(expected, actual_line)
+    end)
 end)

--- a/lua/tests/windows_spec.lua
+++ b/lua/tests/windows_spec.lua
@@ -1,27 +1,27 @@
-package.path = 'lua/telescope/_extensions/?.lua;' .. package.path
+package.path = "lua/telescope/_extensions/?.lua;" .. package.path
 
-local stub = require'luassert.stub'
-local match = require'luassert.match'
+local stub = require("luassert.stub")
+local match = require("luassert.match")
 
-local action_state = require('telescope.actions.state')
+local action_state = require("telescope.actions.state")
 
 describe("tmux windows", function()
-  local windows = require'telescope._extensions.tmux.windows'
+    local windows = require("telescope._extensions.tmux.windows")
 
-  it("should correctly handle duplicate window names in the same session", function()
-    local window_name = "window1"
-    local window_id1 = "1:1"
-    local window_id2 = "1:2"
-    local tmux_commands = require'telescope._extensions.tmux.tmux_commands'
-    local list_windows = stub(tmux_commands, "list_windows")
-    list_windows.on_call_with({format=tmux_commands.window_id_fmt}).returns{window_id1, window_id2}
-    list_windows.on_call_with(match._).returns{window_name, window_name}
-    windows({})
-    local prompt_bufnr = vim.api.nvim_win_get_buf(0)
-    local picker = action_state.get_current_picker(prompt_bufnr)
-    local results = picker.finder.results
-    assert.equals(results[1].value, window_id1)
-    assert.equals(results[2].value, window_id2)
-    list_windows:revert()
-  end)
+    it("should correctly handle duplicate window names in the same session", function()
+        local window_name = "window1"
+        local window_id1 = "1:1"
+        local window_id2 = "1:2"
+        local tmux_commands = require("telescope._extensions.tmux.tmux_commands")
+        local list_windows = stub(tmux_commands, "list_windows")
+        list_windows.on_call_with({ format = tmux_commands.window_id_fmt }).returns({ window_id1, window_id2 })
+        list_windows.on_call_with(match._).returns({ window_name, window_name })
+        windows({})
+        local prompt_bufnr = vim.api.nvim_win_get_buf(0)
+        local picker = action_state.get_current_picker(prompt_bufnr)
+        local results = picker.finder.results
+        assert.equals(results[1].value, window_id1)
+        assert.equals(results[2].value, window_id2)
+        list_windows:revert()
+    end)
 end)

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,6 @@
+column_width = 120
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 4
+quote_style = "AutoPreferDouble"
+no_call_parentheses = false


### PR DESCRIPTION
I created and use a [tmux plugin](https://github.com/trevarj/tmux-open-nvim) that opens a file path (using tmux-fingers) in a running nvim instance, but I think that using telescope-tmux with this change might be an even better workflow for me.

Basically, it greps through the pane contents for strings that look like file paths and then does some path resolution to see if it's a file on the filesystem. Sometimes compilers output paths with line:col appended, so it handles that too and does the appropriate thing for the previewer and opening the file at the correct location for editing.

Feel free to give some feedback, make changes, or just close this PR if it isn't wanted. Thanks.

### Commit Msg
- Added a picker that will grep through all the panes for paths that appear and then attempt to locate them on the filesystem so that they can be edited
- Moved code to respective module
- Added stylua.toml and ran on all files